### PR TITLE
Remove unnecessary logic based on orientation to really fix #2

### DIFF
--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -4,13 +4,13 @@ extension DeviceExt on num {
   /// Calculates the height depending on the device's screen size
   ///
   /// Eg: 20.h -> will take 20% of the screen's height
-  double get h => this * Device.adaptiveHeight / 100;
+  double get h => this * Device.height / 100;
 
   /// Calculates the width depending on the device's screen size
   ///
   /// Eg: 20.h -> will take 20% of the screen's width
-  double get w => this * Device.adaptiveWidth / 100;
+  double get w => this * Device.width / 100;
 
   /// Calculates the sp (Scalable Pixel) depending on the device's screen size
-  double get sp => this * (Device.adaptiveWidth / 3) / 100;
+  double get sp => this * (Device.width / 3) / 100;
 }

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -23,12 +23,6 @@ class Device {
   /// Device's Width
   static late double width;
 
-  /// Height used when calculating the adaptive height in `Adaptive.h`
-  static late double adaptiveHeight;
-
-  /// Width used when calculating the adaptive width in `Adaptive.w`
-  static late double adaptiveWidth;
-
   /// Sets the Screen's size and Device's Orientation,
   /// BoxConstraints, Height, and Width
   static void setScreenSize(
@@ -40,15 +34,6 @@ class Device {
     // Sets screen width and height
     width = boxConstraints.maxWidth;
     height = boxConstraints.maxHeight;
-
-    // Sets adaptive width and height used for `Adaptive.h` caclculation
-    if (orientation == Orientation.portrait) {
-      adaptiveWidth = boxConstraints.maxWidth;
-      adaptiveHeight = boxConstraints.maxHeight;
-    } else {
-      adaptiveWidth = boxConstraints.maxHeight;
-      adaptiveHeight = boxConstraints.maxWidth;
-    }
 
     // Sets ScreenType
     if ((orientation == Orientation.portrait && width < 600) ||


### PR DESCRIPTION
I don't really know what last update should fix, but it did not help on my device. So I am sharing my fix. 
As I already explained in issue #2 flutter layout listener should be aware of orientation and width & height should be set. You dont need any extra logic there