### PR TITLE
Add safe area height and width calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [3.2.0] - 22.07.2023
+## [3.3.0] - 17.01.2024
 
-* Added `sh` and `sw` to calculate the height and width depending on the safe area size
+* Added `sh` and `sw` extension
 
 ## [3.2.0] - 22.07.2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [3.2.0] - 22.07.2023
 
+* Added `sh` and `sw` to calculate the height and width depending on the safe area size
+
+## [3.2.0] - 22.07.2023
+
 * Removed deprecated method
 * Added `spa` which is `altunyurt's` way of calculating sp
 

--- a/README.md
+++ b/README.md
@@ -99,12 +99,14 @@ Device.screenType == ScreenType.tablet
 (If the device's width is larger than this, it will be categorized as a desktop) - Optional: enables *Desktop* `ScreenType` if enabled
 
 ## Extensions
-* `Adaptive.h()` or `.h` - Calculated percentage of the device's height (40.h -> 40% of device's height)
-* `Adaptive.w()` or `.w` - Calculated percentage of the device's width (40.w -> 40% of device's width)
-* `Adaptive.sh()` or `.sh` - Calculated percentage of the safe area height (40.sh -> 40% of safe area height)
-* `Adaptive.sw()` or `.sw` - Calculated percentage of the safe area width (40.sw -> 40% of safe area width)
+* `Adaptive.h()` or `.h` - Calculated percentage of the device's **height** (40.h -> 40% of device's height)
+* `Adaptive.w()` or `.w` - Calculated percentage of the device's **width** (40.w -> 40% of device's width)
 * `Adaptive.sp()` or `.sp` - Calculated sp based on the device's pixel density and aspect ratio (See [FAQ](#sp-dp-difference))
 * `Adaptive.dp()` or `.dp` - Calculated dp based on the device's pixel density (See [FAQ](#sp-dp-difference))
+
+##### *Note: Only use `.sh` and `.sw` if you want height and width to depend on the device's available height and width after applying SafeArea. Use `.h` and `.w` by default.
+* `Adaptive.sh()` or `.sh` - Calculated percentage of the **remaining device's height** after applying `SafeArea` 
+* `Adaptive.sw()` or `.sw` - Calculated percentage of the **remaining device's width** after applying `SafeArea` 
 
 <br />
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Device.screenType == ScreenType.tablet
 ## Extensions
 * `Adaptive.h()` or `.h` - Calculated percentage of the device's height (40.h -> 40% of device's height)
 * `Adaptive.w()` or `.w` - Calculated percentage of the device's width (40.w -> 40% of device's width)
+* `Adaptive.sh()` or `.sh` - Calculated percentage of the safe area height (40.sh -> 40% of safe area height)
+* `Adaptive.sw()` or `.sw` - Calculated percentage of the safe area width (40.sw -> 40% of safe area width)
 * `Adaptive.sp()` or `.sp` - Calculated sp based on the device's pixel density and aspect ratio (See [FAQ](#sp-dp-difference))
 * `Adaptive.dp()` or `.dp` - Calculated dp based on the device's pixel density (See [FAQ](#sp-dp-difference))
 

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -48,8 +48,18 @@ extension DeviceExt on num {
 
   /// Calculates the width depending on the device's screen size
   ///
-  /// Eg: 20.h -> will take 20% of the screen's width
+  /// Eg: 20.w -> will take 20% of the screen's width
   double get w => this * Device.width / 100;
+
+  /// Calculates the width depending on the device's safe area size
+  ///
+  /// Eg: 20.sw -> will take 20% of the safe area width
+  double get sw => this * Device.safeAreaWidth / 100;
+
+  /// Calculates the height depending on the device's safe area size
+  ///
+  /// Eg: 20.sh -> will take 20% of the safe area height
+  double get sh => this * Device.safeAreaHeight / 100;
 
   /// Calculates the sp (Scalable Pixel) depending on the device's pixel
   /// density and aspect ratio

--- a/lib/src/extension.dart
+++ b/lib/src/extension.dart
@@ -51,15 +51,16 @@ extension DeviceExt on num {
   /// Eg: 20.w -> will take 20% of the screen's width
   double get w => this * Device.width / 100;
 
-  /// Calculates the width depending on the device's safe area size
+  /// Calculates the height depending on the remaining device height 
+  /// after using `SafeArea`
+  /// Eg: 20.sh -> will take 20% of the safe area height
+  double get sh => this * Device.safeHeight / 100;
+
+  /// Calculates the width depending on the remaining device width 
+  /// after using `SafeArea`
   ///
   /// Eg: 20.sw -> will take 20% of the safe area width
-  double get sw => this * Device.safeAreaWidth / 100;
-
-  /// Calculates the height depending on the device's safe area size
-  ///
-  /// Eg: 20.sh -> will take 20% of the safe area height
-  double get sh => this * Device.safeAreaHeight / 100;
+  double get sw => this * Device.safeWidth / 100;
 
   /// Calculates the sp (Scalable Pixel) depending on the device's pixel
   /// density and aspect ratio

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -29,6 +29,12 @@ class Device {
   /// Device's Width
   static late double width;
 
+  /// Device's Safe Area Height
+  static late double safeAreaHeight;
+
+  /// Device's Safe Area Width
+  static late double safeAreaWidth;
+
   /// Device's Aspect Ratio
   static late double aspectRatio;
 
@@ -51,6 +57,12 @@ class Device {
     // Sets screen width and height
     width = boxConstraints.maxWidth;
     height = boxConstraints.maxHeight;
+
+    var viewPadding = MediaQuery.of(context).viewPadding;
+    // Sets safe area width and height
+    safeAreaWidth = width - viewPadding.left - viewPadding.right;
+    safeAreaHeight = height - viewPadding.top - viewPadding.bottom;
+
 
     // Sets aspect and pixel ratio
     aspectRatio = constraints.constrainDimensions(width, height).aspectRatio;
@@ -104,8 +116,18 @@ class Adaptive {
 
   /// Calculates the width depending on the device's screen size
   ///
-  /// Eg: 20.h -> will take 20% of the screen's width
+  /// Eg: 20.w -> will take 20% of the screen's width
   static double w(num width) => width.w;
+
+  /// Calculates the height depending on the device's screen size
+  ///
+  /// Eg: 20.sh -> will take 20% of the safe area height
+  static double sh(num height) => height.h;
+
+  /// Calculates the width depending on the device's screen size
+  ///
+  /// Eg: 20.sw -> will take 20% of the safe area width
+  static double sw(num width) => width.w;
 
   /// Calculates the sp (Scalable Pixel) depending on the device's pixel
   /// density and aspect ratio

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -122,12 +122,12 @@ class Adaptive {
   /// Calculates the height depending on the device's screen size
   ///
   /// Eg: 20.sh -> will take 20% of the safe area height
-  static double sh(num height) => height.h;
+  static double sh(num height) => height.sh;
 
   /// Calculates the width depending on the device's screen size
   ///
   /// Eg: 20.sw -> will take 20% of the safe area width
-  static double sw(num width) => width.w;
+  static double sw(num width) => width.sw;
 
   /// Calculates the sp (Scalable Pixel) depending on the device's pixel
   /// density and aspect ratio

--- a/lib/src/helper.dart
+++ b/lib/src/helper.dart
@@ -29,11 +29,14 @@ class Device {
   /// Device's Width
   static late double width;
 
-  /// Device's Safe Area Height
-  static late double safeAreaHeight;
+  // TODO: Reconsider if we should include AppBar and BottomNavigationBar
+  // in safe height calculation
 
-  /// Device's Safe Area Width
-  static late double safeAreaWidth;
+  /// Device's Remaining Height after applying `SafeArea`
+  static late double safeHeight;
+
+  /// Device's Remaining Width after applying `SafeArea`
+  static late double safeWidth;
 
   /// Device's Aspect Ratio
   static late double aspectRatio;
@@ -58,11 +61,10 @@ class Device {
     width = boxConstraints.maxWidth;
     height = boxConstraints.maxHeight;
 
-    var viewPadding = MediaQuery.of(context).viewPadding;
-    // Sets safe area width and height
-    safeAreaWidth = width - viewPadding.left - viewPadding.right;
-    safeAreaHeight = height - viewPadding.top - viewPadding.bottom;
-
+    // Calculates remaining available size after `SafeArea`
+    final viewPadding = MediaQuery.of(context).viewPadding;
+    safeWidth = width - (viewPadding.left + viewPadding.right);
+    safeHeight = height - (viewPadding.top + viewPadding.bottom);
 
     // Sets aspect and pixel ratio
     aspectRatio = constraints.constrainDimensions(width, height).aspectRatio;


### PR DESCRIPTION
## Context


When we use `SafeArea` in flutter,  `Device.height` is not useful to calculate the size percentage. We need to remove additional padding added to avoid errors.
See the following links, for more details about safeArea: [flutter doc ](https://api.flutter.dev/flutter/widgets/SafeArea-class.html) and [stackoverflow](https://stackoverflow.com/a/52319524).

## Solution
This PR contains new functions to calculate height and width percentage when the widget `SafeArea` adds[ view padding ](https://api.flutter.dev/flutter/widgets/MediaQueryData/viewPadding.html) to the device screen size.